### PR TITLE
Avoid a crash when ReturnGroup is null

### DIFF
--- a/Client.lua
+++ b/Client.lua
@@ -68,9 +68,9 @@ end
 -- @treturn Group
 function CLIENT:ClientGroup()
 --trace.f(self.ClassName)
-	local GroupExists = Group.getByName( self.ClientName )
-	if GroupExists::isExist() then
-		return GroupExists
+	local ReturnGroup = Group.getByName( self.ClientName )
+	if ReturnGroup and ReturnGroup::isExist() then
+		return ReturnGroup
 	else
 		return nil
 	end

--- a/Client.lua
+++ b/Client.lua
@@ -69,7 +69,7 @@ end
 function CLIENT:ClientGroup()
 --trace.f(self.ClassName)
 	local ReturnGroup = Group.getByName( self.ClientName )
-	if ReturnGroup and ReturnGroup::isExist() then
+	if ReturnGroup and ReturnGroup:isExist() then
 		return ReturnGroup
 	else
 		return nil

--- a/MissionScripting/MissionScripting.lua
+++ b/MissionScripting/MissionScripting.lua
@@ -1,0 +1,39 @@
+--Initialization script for the Mission lua Environment (SSE)
+
+dofile('Scripts/ScriptingSystem.lua')
+
+Include = {}
+
+Include.LoadPath = 'Scripts/MOOSE'
+Include.Files = {}
+
+Include.File = function( IncludeFile )
+	if not Include.Files[ IncludeFile ] then
+		Include.Files[IncludeFile] = IncludeFile
+		dofile( Include.LoadPath .. "/" .. IncludeFile .. ".lua" )
+		env.info( "Include:" .. IncludeFile .. " loaded." )
+	end
+end
+
+Include.File( "Trace" )
+Include.File( "Routines" )
+Include.File( "Database" )
+Include.File( "StatHandler" )
+
+--Sanitize Mission Scripting environment
+--This makes unavailable some unsecure functions.
+--Mission downloaded from server to client may contain potentialy harmful lua code that may use these functions.
+--You can remove the code below and make availble these functions at your own risk.
+
+local function sanitizeModule(name)
+	_G[name] = nil
+	package.loaded[name] = nil
+end
+
+do
+	--sanitizeModule('os')
+	--sanitizeModule('io')
+	sanitizeModule('lfs')
+	require = nil
+	loadlib = nil
+end


### PR DESCRIPTION
Always checking if ReturnGroup is not null before testing
ReturnGroup::isExist()